### PR TITLE
Improve debugpy import after install

### DIFF
--- a/scripts/manage_vm.py
+++ b/scripts/manage_vm.py
@@ -156,6 +156,13 @@ class LocalBackend(Backend):
                 print(f"Failed to install debugpy: {exc}", file=sys.stderr)
                 return False
             try:
+                import site
+                import importlib
+                usersite = site.getusersitepackages()
+                if usersite not in sys.path:
+                    site.addsitedir(usersite)
+                importlib.reload(site)
+                importlib.invalidate_caches()
                 import debugpy  # noqa: F401
                 return True
             except ImportError:


### PR DESCRIPTION
## Summary
- after installing debugpy, reload site to refresh sys.path

## Testing
- `pytest -q`
- `python scripts/manage_vm.py start --port 5678`
- `python scripts/manage_vm.py halt`


------
https://chatgpt.com/codex/tasks/task_e_68630ace2e98832b922ec8de8fb3d966