### PR TITLE
Improve LockOn setup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ Lock On is an advanced folder security monitoring system that uses intelligent p
 git clone https://github.com/yourusername/LockOn.git
 cd LockOn
 
-# Run setup
-python setup.py
+# Run setup to install dependencies
+python setup.py install --extras
 
-# Install dependencies
-pip install -r requirements.txt
+# Verify the environment
+python setup.py doctor
 ```
+
+The `--extras` flag installs additional features listed in
+`requirements-optional.txt`.
 
 ### Basic Usage
 
@@ -78,6 +81,8 @@ database file is stored at `data/database.db`. Edit this value under the
 database is ignored by Git, so you can freely experiment without polluting the
 repository. The same section contains a `logging` block where you can specify
 the log file path and log level used by the command-line tools and debugger.
+Set the `LOCKON_CONFIG` environment variable to load a different configuration
+file without passing `--config` each time.
 
 ### Security Levels
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,3 @@
+pandas>=2.0.0
+plotly>=5.0.0
+numpy>=1.24.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+
+def _bootstrap() -> None:
+    """Ensure minimal packages required for the setup script are installed."""
+    required = ["rich", "pyyaml", "setuptools"]
+    for pkg in required:
+        try:
+            __import__(pkg)
+        except Exception:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+
+_bootstrap()
+
+from rich.text import Text
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    BarColumn,
+    TimeElapsedColumn,
+)
+
+from src.utils.helpers import log, get_system_info, run_with_spinner, console
+from src.utils.config import ensure_config
+from src.utils.rainbow import NeonPulseBorder
+
+MIN_PYTHON = (3, 10)
+
+LOCKON_ART = r"""
+ _               _     ___
+| |    ___   ___| | __/ _ \ _ __
+| |   / _ \ / __| |/ / | | | '_ \
+| |__| (_) | (__|   <| |_| | | | |
+|_____\___/ \___|_|\_\\___/|_| |_|
+"""
+
+
+def _gradient_line(line: str, offset: int = 0) -> Text:
+    text = Text()
+    n = max(len(line) - 1, 1)
+    for i, ch in enumerate(line):
+        pos = ((i + offset) % len(line)) / n
+        color = _blend("#00eaff", "#ff00d0", pos)
+        text.append(ch, style=color)
+    return text
+
+
+def _blend(c1: str, c2: str, t: float) -> str:
+    c1 = c1.lstrip("#")
+    c2 = c2.lstrip("#")
+    if len(c1) == 3:
+        c1 = "".join(ch * 2 for ch in c1)
+    if len(c2) == 3:
+        c2 = "".join(ch * 2 for ch in c2)
+    r1, g1, b1 = int(c1[0:2], 16), int(c1[2:4], 16), int(c1[4:6], 16)
+    r2, g2, b2 = int(c2[0:2], 16), int(c2[2:4], 16), int(c2[4:6], 16)
+    r = round(r1 + (r2 - r1) * t)
+    g = round(g1 + (g2 - g1) * t)
+    b = round(b1 + (b2 - b1) * t)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def show_setup_banner() -> None:
+    console.clear()
+    lines = LOCKON_ART.strip("\n").splitlines()
+    with NeonPulseBorder(speed=0.05):
+        for step in range(30):
+            console.clear()
+            for line in lines:
+                console.print(_gradient_line(line, step), justify="center")
+            time.sleep(0.05)
+
+    with Progress(
+        SpinnerColumn(style="bold magenta"),
+        BarColumn(bar_width=None),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task("Initializing", total=100)
+        for _ in range(100):
+            progress.update(task, advance=1)
+            time.sleep(0.01)
+
+    console.rule("[bold cyan]LockOn Setup")
+
+
+def check_python_version() -> None:
+    if sys.version_info < MIN_PYTHON:
+        sys.exit(f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or newer required.")
+
+
+def locate_root(start: Path | None = None) -> Path:
+    start = (start or Path(__file__)).resolve()
+    if start.is_file():
+        start = start.parent
+    for path in [start, *start.parents]:
+        if (path / ".git").is_dir() or (path / "requirements.txt").is_file():
+            return path
+    return start
+
+
+def update_repo() -> None:
+    os.chdir(ROOT_DIR)
+    if not (ROOT_DIR / ".git").is_dir():
+        log("No git repository found; skipping update check.")
+        return
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+        ).strip()
+        upstream = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            text=True,
+        ).strip()
+        remote, remote_branch = upstream.split("/", 1)
+        try:
+            with NeonPulseBorder():
+                run_with_spinner(
+                    ["git", "fetch", remote],
+                    message="Fetching updates",
+                )
+        except subprocess.CalledProcessError as exc:
+            log(f"Failed to fetch updates: {exc}")
+            return
+        ahead_behind = subprocess.check_output(
+            [
+                "git",
+                "rev-list",
+                "--left-right",
+                "--count",
+                f"{branch}...{remote}/{remote_branch}",
+            ],
+            text=True,
+        ).strip()
+        ahead, behind = map(int, ahead_behind.split())
+        if behind:
+            log(f"Repository behind upstream by {behind} commit(s); pulling...")
+            with NeonPulseBorder():
+                run_with_spinner(
+                    ["git", "pull", "--ff-only", remote, remote_branch],
+                    message="Pulling updates",
+                )
+            log("Repository updated.")
+        else:
+            log("Repository is up to date.")
+    except Exception as exc:
+        log(f"Failed to update repository: {exc}")
+
+
+def get_root() -> Path:
+    env = os.environ.get("LOCKON_ROOT")
+    if env:
+        return Path(env).expanduser().resolve()
+    try:
+        out = subprocess.check_output([
+            "git",
+            "rev-parse",
+            "--show-toplevel",
+        ], cwd=Path(__file__).resolve().parent, text=True).strip()
+        return Path(out)
+    except Exception:
+        return locate_root()
+
+
+ROOT_DIR = get_root()
+
+
+def get_venv_dir() -> Path:
+    env = os.environ.get("LOCKON_VENV")
+    if env:
+        return Path(env).expanduser().resolve()
+    return ROOT_DIR / ".venv"
+
+
+REQUIREMENTS_FILE = ROOT_DIR / "requirements.txt"
+EXTRAS_FILE = ROOT_DIR / "requirements-optional.txt"
+VENV_DIR = get_venv_dir()
+DEV_PACKAGES = ["debugpy", "flake8"]
+
+
+
+
+def ensure_venv(venv_dir: Path = VENV_DIR, *, python: str | None = None) -> Path:
+    if sys.prefix != sys.base_prefix:
+        return Path(sys.executable)
+
+    if not venv_dir.exists():
+        py_exe = python or sys.executable
+        log(f"Creating virtual environment at {venv_dir} using {py_exe}")
+        with NeonPulseBorder():
+            run_with_spinner([py_exe, "-m", "venv", str(venv_dir)], message="Creating virtualenv")
+
+    python_path = venv_dir / "bin" / "python"
+    if not python_path.exists():
+        python_path = venv_dir / "Scripts" / "python.exe"
+    return python_path
+
+
+def _pip(args: Iterable[str], python: Path | None = None, *, upgrade_pip: bool = False) -> None:
+    py = python or ensure_venv()
+    if upgrade_pip:
+        with NeonPulseBorder():
+            run_with_spinner([str(py), "-m", "pip", "install", "--upgrade", "pip"], message="Upgrading pip")
+    cmd = [str(py), "-m", "pip", *args]
+    log("Running: " + " ".join(cmd))
+    with NeonPulseBorder():
+        run_with_spinner(cmd, message="Installing dependencies")
+
+
+def run_tests(extra: Iterable[str] | None = None) -> None:
+    python = ensure_venv()
+    cmd = [str(python), "-m", "pytest", "-q"]
+    if extra:
+        cmd.extend(extra)
+    log("Running: " + " ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def freeze_requirements(output: Path = ROOT_DIR / "requirements.lock") -> None:
+    """Write installed packages to a lock file."""
+    python = ensure_venv()
+    log(f"Freezing installed packages to {output}")
+    with open(output, "w") as fh:
+        subprocess.check_call([str(python), "-m", "pip", "freeze"], stdout=fh)
+
+
+def ensure_requirements(req_path: Path = REQUIREMENTS_FILE) -> None:
+    """Ensure all packages from *req_path* are installed."""
+    import pkg_resources
+
+    if not req_path.is_file():
+        log(f"Requirements file {req_path} not found")
+        return
+
+    for line in req_path.read_text().splitlines():
+        req = line.strip()
+        if not req or req.startswith("#"):
+            continue
+        try:
+            pkg_resources.require(req)
+        except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
+            log(f"Installing missing or outdated package: {req}", level="warning")
+            _pip(["install", req])
+
+
+def install(
+    requirements: Path | None = None,
+    *,
+    dev: bool = False,
+    upgrade: bool = False,
+    extras: bool = False,
+    skip_update: bool = False,
+) -> None:
+    os.chdir(ROOT_DIR)
+    if not skip_update:
+        update_repo()
+    py = ensure_venv()
+    req_path = requirements or REQUIREMENTS_FILE
+    if req_path.is_file():
+        log(f"Installing requirements from {req_path}")
+        args = ["install", "-r", str(req_path)]
+        if upgrade:
+            args.append("--upgrade")
+        _pip(args, python=py, upgrade_pip=upgrade)
+        ensure_requirements(req_path)
+    else:
+        log(f"Requirements file {req_path} not found")
+
+    if extras and EXTRAS_FILE.is_file():
+        log(f"Installing optional packages from {EXTRAS_FILE}")
+        args = ["install", "-r", str(EXTRAS_FILE)]
+        if upgrade:
+            args.append("--upgrade")
+        _pip(args, python=py)
+        ensure_requirements(EXTRAS_FILE)
+
+    if dev:
+        log("Installing development packages")
+        for pkg in DEV_PACKAGES:
+            args = ["install", pkg]
+            if upgrade:
+                args.append("--upgrade")
+            _pip(args, python=py)
+
+    ensure_config()
+    log("Dependencies installed.")
+
+
+def check_outdated(requirements: Path | None = None, *, upgrade: bool = False) -> None:
+    os.chdir(ROOT_DIR)
+    req_path = requirements or REQUIREMENTS_FILE
+    if not req_path.is_file():
+        log(f"Requirements file {req_path} not found")
+        return
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "list", "--outdated", "--format=json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        pkgs = [f"{p['name']} {p['version']} -> {p['latest_version']}" for p in __import__('json').loads(result.stdout)]
+    except Exception:
+        pkgs = []
+    if pkgs:
+        log("Packages with updates available:\n" + "\n".join(pkgs))
+        if upgrade:
+            log("Upgrading packages...")
+            names = [p.split()[0] for p in pkgs]
+            _pip(["install", "--upgrade", *names])
+    else:
+        log("All packages up to date.")
+
+
+def show_info() -> None:
+    print(f"Project Root: {ROOT_DIR}")
+    print(f"Virtualenv: {VENV_DIR}")
+    print(get_system_info())
+
+
+def doctor() -> None:
+    """Verify Python version and required packages."""
+    check_python_version()
+    ensure_venv()
+    ensure_config()
+    check_outdated()
+    ensure_requirements()
+    freeze_requirements()
+    log("Environment looks good!")
+
+
+if __name__ == "__main__":
+    show_setup_banner()
+    check_python_version()
+    parser = argparse.ArgumentParser(description="Manage LockOn dependencies and show environment info")
+    sub = parser.add_subparsers(dest="command")
+
+    install_p = sub.add_parser("install", help="Install required packages")
+    install_p.add_argument("--requirements", type=Path, help="Path to an alternate requirements file")
+    install_p.add_argument("--dev", action="store_true", help="Install development packages")
+    install_p.add_argument("--upgrade", action="store_true", help="Upgrade packages to latest versions")
+    install_p.add_argument("--extras", action="store_true", help="Install optional packages as well")
+    install_p.add_argument("--skip-update", action="store_true", help="Skip pulling the latest git changes before installing")
+
+    check_p = sub.add_parser("check", help="List outdated packages")
+    check_p.add_argument("--requirements", type=Path, help="Path to the requirements file")
+
+    sub.add_parser("info", help="Show system information")
+    sub.add_parser("doctor", help="Verify Python and package setup")
+    venv_p = sub.add_parser("venv", help="Create or ensure the project virtualenv")
+    venv_p.add_argument("--recreate", action="store_true", help="Recreate the virtual environment")
+    sub.add_parser("clean", help="Remove the project virtualenv")
+    sub.add_parser("update", help="Pull the latest changes from the repository")
+    sub.add_parser("upgrade", help="Upgrade all outdated packages")
+    test_p = sub.add_parser("test", help="Run the test suite")
+    test_p.add_argument("extra", nargs="*", help="Additional pytest arguments")
+    freeze_p = sub.add_parser("freeze", help="Write installed packages to a lock file")
+    freeze_p.add_argument("--output", type=Path, default=ROOT_DIR / "requirements.lock", help="Output lock file")
+
+    args = parser.parse_args()
+    if args.command == "check":
+        check_outdated(requirements=args.requirements)
+    elif args.command == "upgrade":
+        check_outdated(requirements=None, upgrade=True)
+    elif args.command == "info":
+        show_info()
+    elif args.command == "doctor":
+        doctor()
+    elif args.command == "venv":
+        if args.recreate and VENV_DIR.exists():
+            import shutil
+            shutil.rmtree(VENV_DIR)
+        ensure_venv()
+    elif args.command == "clean":
+        import shutil
+        if VENV_DIR.exists():
+            shutil.rmtree(VENV_DIR)
+            log("Virtualenv removed.")
+        else:
+            log("No virtualenv to remove.")
+    elif args.command == "test":
+        run_tests(args.extra)
+    elif args.command == "freeze":
+        freeze_requirements(args.output)
+    elif args.command == "update":
+        update_repo()
+    else:
+        install(
+            requirements=getattr(args, "requirements", None),
+            dev=getattr(args, "dev", False),
+            upgrade=getattr(args, "upgrade", False),
+            extras=getattr(args, "extras", False),
+            skip_update=getattr(args, "skip_update", False),
+        )
+
+

--- a/src/core/monitor_cli.py
+++ b/src/core/monitor_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import os
 
 from utils.logger import SecurityLogger
-from utils.config import load_config
+from utils.config import load_config, ensure_config
 from utils.database import Database
 from core.monitor import FolderMonitor
 
@@ -21,7 +21,9 @@ class LockOnCLI:
         debug: bool = False,
         debug_port: int = 5678,
     ) -> None:
-        self.config = load_config(config_path or Path("config.yaml"))
+        cfg_path = config_path or Path("config.yaml")
+        ensure_config(cfg_path)
+        self.config = load_config(cfg_path)
         log_cfg = self.config.get("logging", {})
         self.logger = SecurityLogger(
             Path(log_cfg.get("file", "data/logs/security.log")),

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,23 +1,43 @@
+from __future__ import annotations
+
+import os
 from pathlib import Path
 import yaml
 
-CONFIG_PATH = Path("config.yaml")
+CONFIG_ENV = "LOCKON_CONFIG"
+CONFIG_PATH = Path(os.environ.get(CONFIG_ENV, "config.yaml"))
 
 
-def load_config(path: Path = CONFIG_PATH):
+def ensure_config(path: Path = CONFIG_PATH) -> None:
+    """Create a default configuration file if it does not exist."""
+    if path.exists():
+        return
+    sample = {
+        "logging": {"file": "data/logs/app.log", "level": "INFO"},
+        "monitor": {"paths": ["."], "recursive": True},
+        "database": {"path": "data/database.db"},
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(sample))
+
+
+def load_config(path: Path | None = None) -> dict:
     """Load YAML configuration as a dictionary."""
-    if not path.exists():
+    final = Path(os.environ.get(CONFIG_ENV, str(path or CONFIG_PATH))).expanduser()
+    if not final.exists():
         return {}
-    with open(path) as f:
+    with open(final) as f:
         return yaml.safe_load(f) or {}
 
 
 class Config(dict):
     """Simple wrapper to provide attribute-style access."""
 
-    def __init__(self, path: Path = CONFIG_PATH):
-        super().__init__(load_config(path))
-        self.path = path
+    def __init__(self, path: Path | None = None):
+        final = Path(os.environ.get(CONFIG_ENV, str(path or CONFIG_PATH))).expanduser()
+        super().__init__(load_config(final))
+        self.path = final
 
     def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(yaml.safe_dump(dict(self)))

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import platform
+import subprocess
+from datetime import datetime
+from typing import Iterable
+import psutil
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from .logger import SecurityLogger
+
+console = Console()
+logger = SecurityLogger()
+
+
+def log(message: str, level: str = "info") -> None:
+    """Log a message to the console and security logger."""
+    console.log(message)
+    getattr(logger, level, logger.info)(message)
+
+
+def get_system_info() -> str:
+    """Return detailed system information."""
+    mem = psutil.virtual_memory().total / 1024 ** 3
+    return (
+        f"Platform: {platform.system()} {platform.release()} ({platform.machine()})\n"
+        f"Python: {platform.python_version()}\n"
+        f"CPU: {psutil.cpu_count(logical=True)} cores\n"
+        f"Memory: {mem:.1f} GB"
+    )
+
+
+def run_with_spinner(cmd: Iterable[str], message: str = "Working") -> None:
+    """Run a command while showing a spinner."""
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("{task.description}"),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task(message, start=False)
+        progress.start_task(task)
+        try:
+            subprocess.check_call(list(cmd))
+        except subprocess.CalledProcessError as exc:
+            log(f"Command failed: {exc}", level="error")
+            raise
+        else:
+            progress.update(task, completed=1)
+

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import ContextDecorator
+from rich.console import Console
+from rich.live import Live
+from rich.text import Text
+
+console = Console()
+
+
+class NeonPulseBorder(ContextDecorator):
+    """Animated neon border used during setup."""
+
+    def __init__(self, speed: float = 0.1, width: int = 60) -> None:
+        self.speed = speed
+        self.width = width
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._animate, daemon=True)
+        self._thread.start()
+        return self
+
+    def _animate(self) -> None:
+        step = 0
+        with Live(console=console, refresh_per_second=30):
+            while not self._stop.is_set():
+                color = "#ff00d0" if step % 2 else "#00eaff"
+                console.rule(Text(" " * self.width, style=color))
+                step += 1
+                time.sleep(self.speed)
+
+    def __exit__(self, exc_type, exc, tb):
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+        console.rule("[bold magenta]")
+        return False
+


### PR DESCRIPTION
## Summary
- tie helper logging into SecurityLogger and handle command failures with spinners
- animate neon border with a thread and live output
- expand setup script with optional extras, config creation, and `doctor` command
- fix LockOn banner and add `freeze` subcommand to save installed packages
- add dependency verification and document usage of the improved setup
- bootstrap basic packages automatically so the setup script runs even on a fresh system
- integrate `ensure_config` and optional requirements across the project
- detail system info and config environment variable in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650895843c832bae0e0cb112682063