### PR TITLE
Fix imports and support script mode

### DIFF
--- a/src/core/analyzer.py
+++ b/src/core/analyzer.py
@@ -1,8 +1,7 @@
 """
 Pattern Analyzer - Analyze files and behaviors for threats
 """
-import os
-import re
+
 try:
     import magic  # type: ignore
 except ImportError:  # pragma: no cover - fallback when python-magic is missing
@@ -10,7 +9,7 @@ except ImportError:  # pragma: no cover - fallback when python-magic is missing
     import mimetypes
 import hashlib
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict
 from datetime import datetime
 
 from core.intelligence import IntelligenceEngine
@@ -19,7 +18,9 @@ from utils.psutil_compat import psutil
 
 class ThreatAnalysis:
     """Threat analysis result"""
-    def __init__(self, level: str, type: str, confidence: float, details: Dict):
+    def __init__(
+        self, level: str, type: str, confidence: float, details: Dict
+    ) -> None:
         self.level = level  # low, medium, high, critical
         self.type = type    # malware, ransomware, trojan, etc
         self.confidence = confidence
@@ -89,7 +90,7 @@ class PatternAnalyzer:
                 for chunk in iter(lambda: f.read(4096), b""):
                     hash_md5.update(chunk)
             return hash_md5.hexdigest()
-        except:
+        except Exception:
             return ""
 
     def _check_mime_mismatch(self, filepath: Path) -> float:
@@ -118,7 +119,7 @@ class PatternAnalyzer:
             if extension not in ['.exe', '.dll', '.com'] and 'executable' in mime_type:
                 return 0.9
 
-        except:
+        except Exception:
             pass
 
         return 0.0
@@ -195,7 +196,7 @@ class PatternAnalyzer:
             if any(str(filepath).endswith(ext) for ext in ransom_extensions):
                 return True
 
-        except:
+        except Exception:
             pass
 
         return False
@@ -248,7 +249,7 @@ class PatternAnalyzer:
             if self._check_suspicious_parent(process):
                 return True
 
-        except:
+        except Exception:
             pass
 
         return False
@@ -266,7 +267,7 @@ class PatternAnalyzer:
                     if process.name().lower() not in ['python.exe', 'node.exe']:
                         return True
 
-        except:
+        except Exception:
             pass
 
         return False

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -2,7 +2,15 @@
 Lock On - Main UI Application
 Magnificent security monitoring interface
 """
-from .ctk import ctk
+if __package__ in {None, ""}:
+    import sys as _sys
+    from pathlib import Path as _Path
+    _sys.path.append(str(_Path(__file__).resolve().parent))
+    __package__ = "ui"
+try:
+    from .ctk import ctk
+except ImportError:  # pragma: no cover - allow running as a script
+    from ui.ctk import ctk  # type: ignore
 from typing import Dict, Optional
 import sys
 import json
@@ -15,11 +23,15 @@ from .permissions_view import PermissionsView
 from .intelligence_view import IntelligenceView
 
 # Import core
-from ..core.monitor import FolderMonitor
-from ..core.intelligence import IntelligenceEngine
-from ..core.permissions import PermissionManager
-from ..utils.config import Config
-from ..utils.logger import SecurityLogger
+# Import core modules using absolute paths so the application can be
+# executed from any entry point without relying on relative package
+# structure. This avoids ``ImportError: attempted relative import beyond
+# top-level package`` when ``src`` is added directly to ``sys.path``.
+from core.monitor import FolderMonitor
+from core.intelligence import IntelligenceEngine
+from core.permissions import PermissionManager
+from utils.config import Config
+from utils.logger import SecurityLogger
 
 # Set theme
 ctk.set_appearance_mode("dark")

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1,7 +1,10 @@
 """
 Dashboard View - Main overview of system security status
 """
-from .ctk import ctk
+try:
+    from .ctk import ctk
+except ImportError:  # pragma: no cover - allow running as a script
+    from ui.ctk import ctk  # type: ignore
 from datetime import datetime
 import threading
 from typing import Dict, List

--- a/src/ui/intelligence_view.py
+++ b/src/ui/intelligence_view.py
@@ -1,7 +1,10 @@
 """
 Intelligence View - Configure AI patterns and threat detection
 """
-from .ctk import ctk
+try:
+    from .ctk import ctk
+except ImportError:  # pragma: no cover - allow running as a script
+    from ui.ctk import ctk  # type: ignore
 from tkinter import messagebox
 import json
 

--- a/src/ui/monitor_view.py
+++ b/src/ui/monitor_view.py
@@ -1,7 +1,10 @@
 """
 Monitor View - Real-time file system monitoring interface
 """
-from .ctk import ctk
+try:
+    from .ctk import ctk
+except ImportError:  # pragma: no cover - allow running as a script
+    from ui.ctk import ctk  # type: ignore
 from datetime import datetime
 import threading
 from pathlib import Path

--- a/src/ui/permissions_view.py
+++ b/src/ui/permissions_view.py
@@ -1,7 +1,10 @@
 """
 Permissions View - Manage access rules and security policies
 """
-from .ctk import ctk
+try:
+    from .ctk import ctk
+except ImportError:  # pragma: no cover - allow running as a script
+    from ui.ctk import ctk  # type: ignore
 from tkinter import messagebox
 import json
 


### PR DESCRIPTION
## Summary
- make UI modules runnable as scripts by falling back to absolute imports
- ensure core modules use absolute imports

## Testing
- `pytest -q`
- `python src/ui/app.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68652dc0eb60832b9b4a5b1ca67bce29