### PR TITLE
Fix FileSystemEventHandler fallback

### DIFF
--- a/src/core/monitor.py
+++ b/src/core/monitor.py
@@ -2,6 +2,8 @@
 Folder Monitor - Real-time file system monitoring with threat detection
 """
 
+from __future__ import annotations
+
 import os
 import time
 import threading
@@ -40,81 +42,81 @@ except Exception:  # pragma: no cover - provide fallback
     class FileSystemEventHandler:
         """Base event handler used when ``watchdog`` is unavailable."""
 
-        class _PollingObserver:
-            """Very small polling based observer as a fallback."""
+    class _PollingObserver:
+        """Very small polling based observer as a fallback."""
 
-            def __init__(self, interval: float = 1.0) -> None:
-                self.interval = interval
-                self._handlers: list[
-                    tuple[FileSystemEventHandler, Path, bool, dict[str, float]]
-                ] = []
-                self._thread: threading.Thread | None = None
-                self._running = False
+        def __init__(self, interval: float = 1.0) -> None:
+            self.interval = interval
+            self._handlers: list[
+                tuple[FileSystemEventHandler, Path, bool, dict[str, float]]
+            ] = []
+            self._thread: threading.Thread | None = None
+            self._running = False
 
-            def schedule(
-                self, handler: FileSystemEventHandler, path: str, recursive: bool = True
-            ) -> None:
-                self._handlers.append((handler, Path(path), recursive, {}))
+        def schedule(
+            self, handler: FileSystemEventHandler, path: str, recursive: bool = True
+        ) -> None:
+            self._handlers.append((handler, Path(path), recursive, {}))
 
-            def start(self) -> None:
-                if self._running:
-                    return
-                self._running = True
-                self._thread = threading.Thread(target=self._loop, daemon=True)
-                self._thread.start()
+        def start(self) -> None:
+            if self._running:
+                return
+            self._running = True
+            self._thread = threading.Thread(target=self._loop, daemon=True)
+            self._thread.start()
 
-            def _loop(self) -> None:
-                while self._running:
-                    for handler, path, recursive, snapshot in self._handlers:
-                        self._scan(handler, path, recursive, snapshot)
-                    time.sleep(self.interval)
+        def _loop(self) -> None:
+            while self._running:
+                for handler, path, recursive, snapshot in self._handlers:
+                    self._scan(handler, path, recursive, snapshot)
+                time.sleep(self.interval)
 
-            def _scan(
-                self,
-                handler: FileSystemEventHandler,
-                path: Path,
-                recursive: bool,
-                snapshot: dict[str, float],
-            ) -> None:
-                current: dict[str, float] = {}
-                walker = os.walk(path) if recursive else [(path, [], os.listdir(path))]
-                for root, _, files in walker:
-                    for name in files:
-                        fp = Path(root) / name
-                        try:
-                            mtime = fp.stat().st_mtime
-                        except FileNotFoundError:
-                            continue
-                        current[str(fp)] = mtime
-                        if str(fp) not in snapshot:
-                            event = FileSystemEvent(str(fp))
-                            if hasattr(handler, "on_created"):
-                                handler.on_created(event)
-                        elif snapshot[str(fp)] != mtime:
-                            event = FileSystemEvent(str(fp))
-                            if hasattr(handler, "on_modified"):
-                                handler.on_modified(event)
+        def _scan(
+            self,
+            handler: FileSystemEventHandler,
+            path: Path,
+            recursive: bool,
+            snapshot: dict[str, float],
+        ) -> None:
+            current: dict[str, float] = {}
+            walker = os.walk(path) if recursive else [(path, [], os.listdir(path))]
+            for root, _, files in walker:
+                for name in files:
+                    fp = Path(root) / name
+                    try:
+                        mtime = fp.stat().st_mtime
+                    except FileNotFoundError:
+                        continue
+                    current[str(fp)] = mtime
+                    if str(fp) not in snapshot:
+                        event = FileSystemEvent(str(fp))
+                        if hasattr(handler, "on_created"):
+                            handler.on_created(event)
+                    elif snapshot[str(fp)] != mtime:
+                        event = FileSystemEvent(str(fp))
+                        if hasattr(handler, "on_modified"):
+                            handler.on_modified(event)
 
-                # handle deletions
-                for old in list(snapshot):
-                    if old not in current:
-                        event = FileSystemEvent(old)
-                        if hasattr(handler, "on_deleted"):
-                            handler.on_deleted(event)
-                        snapshot.pop(old, None)
+            # handle deletions
+            for old in list(snapshot):
+                if old not in current:
+                    event = FileSystemEvent(old)
+                    if hasattr(handler, "on_deleted"):
+                        handler.on_deleted(event)
+                    snapshot.pop(old, None)
 
-                snapshot.update(current)
+            snapshot.update(current)
 
-            def stop(self) -> None:
-                self._running = False
-                if self._thread:
-                    self._thread.join()
+        def stop(self) -> None:
+            self._running = False
+            if self._thread:
+                self._thread.join()
 
-            def join(self, timeout: float | None = None) -> None:
-                if self._thread:
-                    self._thread.join(timeout)
+        def join(self, timeout: float | None = None) -> None:
+            if self._thread:
+                self._thread.join(timeout)
 
-        Observer = _PollingObserver
+    Observer = _PollingObserver
 
 
 from utils.psutil_compat import psutil

--- a/tests/test_fallback_observer.py
+++ b/tests/test_fallback_observer.py
@@ -1,0 +1,43 @@
+import importlib
+import builtins
+import time
+from pathlib import Path
+
+import pytest
+
+import src.core.monitor as monitor
+
+
+def test_polling_observer_fallback(monkeypatch, tmp_path):
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("watchdog"):
+            raise ModuleNotFoundError("watchdog")
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    m = importlib.reload(monitor)
+    assert m.WATCHDOG_AVAILABLE is False
+
+    events = []
+
+    class Handler(m.FileSystemEventHandler):
+        def on_created(self, event):
+            events.append(event.src_path)
+
+    obs = m.Observer(interval=0.1)
+    obs.schedule(Handler(), str(tmp_path), recursive=False)
+    obs.start()
+    (tmp_path / "foo.txt").write_text("hi")
+
+    for _ in range(30):
+        if events:
+            break
+        time.sleep(0.05)
+
+    obs.stop()
+    assert any("foo.txt" in e for e in events)
+
+    monkeypatch.setattr(builtins, "__import__", orig_import)
+    importlib.reload(monitor)


### PR DESCRIPTION
## Summary
- refine fallback implementation in `src/core/monitor.py`
- ensure polling observer is defined when watchdog is missing
- add regression test for polling observer fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866cf298950832b85afac5705680be1