### PR TITLE
Improve network monitor psutil fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ python setup.py doctor
 The `--extras` flag installs additional features listed in
 `requirements-optional.txt`.
 
+Network monitoring relies on the `psutil` package. If it isn't
+available, Lock On uses a simplified built-in stub so the monitor can
+still run, albeit with reduced information.
+
 For full malware detection capabilities you also need the
 `yara-python` package which is included in `requirements.txt`.
 If you installed dependencies manually make sure to run:

--- a/tests/test_network_monitor_nopsutil.py
+++ b/tests/test_network_monitor_nopsutil.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+from security.network_monitor import NetworkMonitor
+from utils import psutil_compat
+
+class DummyPM:
+    def ensure_active(self, privs, impersonate=True):
+        return []
+
+def test_network_monitor_fallback(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'psutil', None)
+    importlib.reload(psutil_compat)
+    nm_mod = importlib.reload(importlib.import_module('security.network_monitor'))
+    def fake_net_connections(kind='inet'):
+        Addr = SimpleNamespace
+        return [SimpleNamespace(raddr=Addr(ip='1.2.3.4', port=4444), pid=1)]
+    monkeypatch.setattr(psutil_compat.psutil, 'net_connections', fake_net_connections, raising=False)
+    nm = nm_mod.NetworkMonitor({'suspicious_ports':[4444]}, priv_manager=DummyPM())
+    results = nm.check_now()
+    assert len(results) == 1


### PR DESCRIPTION
## Summary
- provide minimal dataclass fallback for psutil connection type
- keep environment manager functional

## Testing
- `pytest -q tests/test_network_monitor.py tests/test_network_monitor_nopsutil.py`
- `python scripts/manage_vm.py doctor`


------
https://chatgpt.com/codex/tasks/task_e_6866fb207ef4832b9a83baa237757f38