### PR TITLE
Fix Tk fallback widget options

### DIFF
--- a/src/ui/ctk.py
+++ b/src/ui/ctk.py
@@ -13,22 +13,150 @@ try:  # pragma: no cover - optional dependency
     import customtkinter as ctk  # type: ignore
 except Exception:  # pragma: no cover - lightweight fallback
     import tkinter as tk
+    from tkinter import ttk
+
+    def _map_color_kwargs(kwargs: dict[str, object]) -> None:
+        """Translate ``customtkinter`` style keys to ``tkinter`` equivalents."""
+
+        mapping = {
+            "fg_color": "bg",
+            "text_color": "fg",
+            "border_width": "bd",
+        }
+
+        for ctk_key, tk_key in mapping.items():
+            if ctk_key in kwargs:
+                kwargs[tk_key] = kwargs.pop(ctk_key)
+
+        # discard unsupported options
+        for key in [
+            "corner_radius",
+            "border_color",
+            "hover_color",
+            "number_of_steps",
+        ]:
+            kwargs.pop(key, None)
+
+
+    class _CTkWindow(tk.Tk):
+        """Fallback root window supporting CTk options."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            _map_color_kwargs(kwargs)
+            super().__init__(*args, **kwargs)
+
+        def configure(self, cnf=None, **kw):  # type: ignore[override]
+            if cnf is None:
+                cnf = {}
+            _map_color_kwargs(cnf)
+            _map_color_kwargs(kw)
+            return super().configure(cnf, **kw)
+
+
+    class _CTkFrame(tk.Frame):
+        """Fallback frame supporting a subset of CTk options."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            _map_color_kwargs(kwargs)
+            super().__init__(master, *args, **kwargs)
+
+        def configure(self, cnf=None, **kw):  # type: ignore[override]
+            if cnf is None:
+                cnf = {}
+            _map_color_kwargs(cnf)
+            _map_color_kwargs(kw)
+            return super().configure(cnf, **kw)
+
+
+    class _CTkLabel(tk.Label):
+        """Fallback label with CTk option mapping."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            _map_color_kwargs(kwargs)
+            super().__init__(master, *args, **kwargs)
+
+        def configure(self, cnf=None, **kw):  # type: ignore[override]
+            if cnf is None:
+                cnf = {}
+            _map_color_kwargs(cnf)
+            _map_color_kwargs(kw)
+            return super().configure(cnf, **kw)
+
+
+    class _CTkButton(tk.Button):
+        """Fallback button mapping CTk options."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            _map_color_kwargs(kwargs)
+            super().__init__(master, *args, **kwargs)
+
+        def configure(self, cnf=None, **kw):  # type: ignore[override]
+            if cnf is None:
+                cnf = {}
+            _map_color_kwargs(cnf)
+            _map_color_kwargs(kw)
+            return super().configure(cnf, **kw)
+
+
+    class _CTkProgressBar(tk.Scale):
+        """Simple progress bar using :class:`tk.Scale`. Value range is 0..1."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            _map_color_kwargs(kwargs)
+            kwargs.setdefault("from_", 0.0)
+            kwargs.setdefault("to", 1.0)
+            kwargs.setdefault("orient", "horizontal")
+            kwargs.setdefault("showvalue", False)
+            super().__init__(master, *args, **kwargs)
+
+        def set(self, value: float) -> None:
+            tk.Scale.set(self, value)
+
+
+    class _CTkSlider(tk.Scale):
+        """Simplified slider implementation."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            _map_color_kwargs(kwargs)
+            kwargs.setdefault("orient", "horizontal")
+            if "width" in kwargs:
+                kwargs["length"] = kwargs.pop("width")
+            super().__init__(master, *args, **kwargs)
+
+
+    class _CTkTabview(tk.Frame):
+        """Basic tab container used to group frames."""
+
+        def __init__(self, master=None, *args, **kwargs):
+            super().__init__(master, *args, **kwargs)
+            self._tabs: dict[str, tk.Frame] = {}
+
+        def add(self, name: str) -> None:
+            frame = tk.Frame(self)
+            frame.pack_forget()
+            self._tabs[name] = frame
+
+        def tab(self, name: str) -> tk.Frame:
+            return self._tabs[name]
+
 
     class _SimpleCTk:
         """Very small subset of the ``customtkinter`` API."""
 
-        # basic widget classes
-        CTk = tk.Tk
-        CTkFrame = tk.Frame
-        CTkButton = tk.Button
-        CTkLabel = tk.Label
+        CTk = _CTkWindow
+        CTkFrame = _CTkFrame
+        CTkButton = _CTkButton
+        CTkLabel = _CTkLabel
         CTkCanvas = tk.Canvas
         CTkScrollbar = tk.Scrollbar
-        CTkProgressBar = tk.Scale
-        CTkScrollableFrame = tk.Frame
+        CTkProgressBar = _CTkProgressBar
+        CTkScrollableFrame = _CTkFrame
         CTkTextbox = tk.Text
         CTkOptionMenu = tk.OptionMenu
-        CTkTabview = tk.Frame
+        CTkTabview = _CTkTabview
+        CTkSlider = _CTkSlider
+        CTkRadioButton = tk.Radiobutton
+        CTkCheckBox = tk.Checkbutton
 
         StringVar = tk.StringVar
         IntVar = tk.IntVar

--- a/tests/test_ctk_fallback.py
+++ b/tests/test_ctk_fallback.py
@@ -1,0 +1,57 @@
+import builtins
+import importlib
+import sys
+import types
+
+
+def test_ctk_window_maps_options(monkeypatch):
+    """CTk fallback should map style options to Tk names."""
+
+    # Force ImportError for customtkinter
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "customtkinter":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    class DummyTk:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+            self.configure_calls = []
+
+        def configure(self, cnf=None, **kw):
+            if cnf is None:
+                cnf = {}
+            self.configure_calls.append({**cnf, **kw})
+
+    tkmod = types.SimpleNamespace(
+        Tk=DummyTk,
+        Frame=object,
+        Label=object,
+        Button=object,
+        Canvas=object,
+        Scrollbar=object,
+        Scale=object,
+        Text=object,
+        OptionMenu=object,
+        Radiobutton=object,
+        Checkbutton=object,
+        StringVar=object,
+        IntVar=object,
+        DoubleVar=object,
+    )
+    tkmod.ttk = types.SimpleNamespace()
+
+    monkeypatch.setitem(sys.modules, "tkinter", tkmod)
+    monkeypatch.setitem(sys.modules, "tkinter.ttk", tkmod.ttk)
+
+    sys.modules.pop("src.ui.ctk", None)
+    ctk = importlib.import_module("src.ui.ctk")
+
+    win = ctk.ctk.CTk()
+    win.configure(fg_color="red", text_color="blue", border_width=3)
+
+    assert win.configure_calls == [{"bg": "red", "fg": "blue", "bd": 3}]


### PR DESCRIPTION
## Summary
- improve `customtkinter` compatibility layer
- map common CTk options like `fg_color` and `text_color` to Tk options
- provide simple wrappers for buttons, labels, frames, etc.
- ensure progress bar and slider work with Tk fallback
- extend fallback to support `CTk` window configuration
- add test for `_CTkWindow` option mapping

## Testing
- `pytest tests/test_ctk_fallback.py -q`
- `python scripts/manage_vm.py doctor`


------
https://chatgpt.com/codex/tasks/task_e_686705e19fec832bac17107a279e4842