### PR TITLE
Handle transparent color in fallback ctk

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Under the hood it calls a Python environment manager that automatically selects
 the best available backend (Vagrant preferred, then Docker, otherwise local):
 
 ```bash
-python scripts/manage_vm.py start
+python scripts/manage_vm.py start --open-vscode
 ```
 
 `manage_vm.py` dynamically selects a **Vagrant**, **Docker**, or **local**

--- a/src/ui/ctk.py
+++ b/src/ui/ctk.py
@@ -26,7 +26,10 @@ except Exception:  # pragma: no cover - lightweight fallback
 
         for ctk_key, tk_key in mapping.items():
             if ctk_key in kwargs:
-                kwargs[tk_key] = kwargs.pop(ctk_key)
+                value = kwargs.pop(ctk_key)
+                if isinstance(value, str) and value.lower() == "transparent":
+                    value = ""
+                kwargs[tk_key] = value
 
         # discard unsupported options
         for key in [


### PR DESCRIPTION
## Summary
- handle `transparent` fg_color in the customtkinter fallback
- map the value to an empty string so Tk does not error out
- test transparent color mapping
- note how to auto-launch VS Code when starting the debug VM

## Testing
- `pytest tests/test_ctk_fallback.py::test_transparent_color_mapping -q`

------
https://chatgpt.com/codex/tasks/task_e_68670f2bd0ec832ba6e9ca1e509c995a