### PR TITLE
Fix transparent color handling in CTk fallback

### DIFF
--- a/src/ui/ctk.py
+++ b/src/ui/ctk.py
@@ -27,7 +27,8 @@ except Exception:  # pragma: no cover - lightweight fallback
             if ctk_key in kwargs:
                 value = kwargs.pop(ctk_key)
                 if isinstance(value, str) and value.lower() == "transparent":
-                    value = ""
+                    # Do not set the color at all to allow Tk defaults
+                    continue
                 kwargs[tk_key] = value
 
         # discard unsupported options

--- a/tests/test_ctk_fallback.py
+++ b/tests/test_ctk_fallback.py
@@ -58,7 +58,7 @@ def test_ctk_window_maps_options(monkeypatch):
 
 
 def test_transparent_color_mapping(monkeypatch):
-    """Transparent color should become empty string in fallback."""
+    """Transparent color should be ignored in fallback."""
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
@@ -98,4 +98,4 @@ def test_transparent_color_mapping(monkeypatch):
 
     widget = ctk.ctk.CTkFrame(fg_color="transparent")
 
-    assert widget.kwargs.get("bg") == ""
+    assert "bg" not in widget.kwargs


### PR DESCRIPTION
## Summary
- avoid assigning empty color strings in `ctk` compatibility layer
- update fallback test to match new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686724e13368832b96cbc8451effafb1